### PR TITLE
feat: support custom name parser

### DIFF
--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -613,12 +613,6 @@ function colorizer.reload_all_buffers()
   end
 end
 
-function colorizer.detach_all_buffers()
-  for buf, _ in pairs(BUFFER_OPTIONS) do
-    colorizer.detach_from_buffer(buf)
-  end
-end
-
 --- Clear the highlight cache and reload all buffers.
 function colorizer.clear_highlight_cache()
   clear_hl_cache()

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -66,7 +66,6 @@ end
 
 local MATCHER_CACHE = {}
 
-
 function matcher.clear_cache()
   MATCHER_CACHE = {}
 end
@@ -77,6 +76,9 @@ end
 ---@param options table: options created in `colorizer.setup`
 ---@return function|boolean: function which will just parse the line for enabled parsers
 function matcher.make(options)
+  if not options then
+    return false
+  end
 
   local enable_names = options.names
   local enable_sass = options.sass and options.sass.enable
@@ -101,6 +103,9 @@ function matcher.make(options)
     + (enable_tailwind == "both" and 1 or 9)
     + (enable_sass and 1 or 10)
 
+  if matcher_key == 0 then
+    return false
+  end
 
   local loop_parse_fn = MATCHER_CACHE[matcher_key]
   if loop_parse_fn then

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -65,15 +65,18 @@ function matcher.compile(matchers, matchers_trie)
 end
 
 local MATCHER_CACHE = {}
+
+
+function matcher.clear_cache()
+  MATCHER_CACHE = {}
+end
+
 ---Parse the given options and return a function with enabled parsers.
 --if no parsers enabled then return false
 --Do not try make the function again if it is present in the cache
 ---@param options table: options created in `colorizer.setup`
 ---@return function|boolean: function which will just parse the line for enabled parsers
 function matcher.make(options)
-  if not options then
-    return false
-  end
 
   local enable_names = options.names
   local enable_sass = options.sass and options.sass.enable
@@ -98,9 +101,6 @@ function matcher.make(options)
     + (enable_tailwind == "both" and 1 or 9)
     + (enable_sass and 1 or 10)
 
-  if matcher_key == 0 then
-    return false
-  end
 
   local loop_parse_fn = MATCHER_CACHE[matcher_key]
   if loop_parse_fn then
@@ -112,7 +112,7 @@ function matcher.make(options)
   matchers.max_prefix_length = 0
 
   if enable_names then
-    matchers.color_name_parser = { tailwind = options.tailwind }
+    matchers.color_name_parser = { tailwind = options.tailwind, custom = options.custom }
   end
 
   if enable_sass then

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -57,7 +57,17 @@ function parser.name_parser(line, i, opts)
         end
       end
     end
+
     TAILWIND_ENABLED = opts.tailwind
+  end
+
+  if opts and opts.custom then
+    for k, v in pairs(opts.custom) do
+      COLOR_NAME_MINLEN = COLOR_NAME_MINLEN and min(#k, COLOR_NAME_MINLEN) or #k
+      COLOR_NAME_MAXLEN = COLOR_NAME_MAXLEN and max(#k, COLOR_NAME_MAXLEN) or #k
+      COLOR_MAP[k] = string.sub(v, 2)
+      COLOR_TRIE:insert(k)
+    end
   end
 
   if #line < i + COLOR_NAME_MINLEN - 1 then

--- a/lua/colorizer/trie.lua
+++ b/lua/colorizer/trie.lua
@@ -21,7 +21,7 @@ local ffi = require "ffi"
 ffi.cdef [[
 struct Trie {
 	bool is_leaf;
-	struct Trie* character[62];
+	struct Trie* character[63];
 };
 void *malloc(size_t size);
 void free(void *ptr);
@@ -41,7 +41,7 @@ local function trie_destroy(trie)
   if trie == nil then
     return
   end
-  for i = 0, 61 do
+  for i = 0, 62 do
     local child = trie.character[i]
     if child ~= nil then
       trie_destroy(child)
@@ -52,11 +52,12 @@ end
 
 local total_char = 255
 local INDEX_LOOKUP_TABLE = ffi.new("uint8_t[?]", total_char)
-local CHAR_LOOKUP_TABLE = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+local CHAR_LOOKUP_TABLE = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
 do
   local b = string.byte
   local extra_char = {
     [b "-"] = true,
+    [b "_"] = true,
   }
   local byte = { ["0"] = b "0", ["9"] = b "9", ["a"] = b "a", ["A"] = b "A", ["z"] = b "z", ["Z"] = b "Z" }
   for i = 0, total_char do
@@ -156,7 +157,7 @@ end
 --- Printing utilities
 
 local function index_to_char(index)
-  if index < 0 or index > 61 then
+  if index < 0 or index > 62 then
     return
   end
   return CHAR_LOOKUP_TABLE:sub(index + 1, index + 1)
@@ -167,7 +168,7 @@ local function trie_as_table(trie)
     return nil
   end
   local children = {}
-  for i = 0, 61 do
+  for i = 0, 62 do
     local child = trie.character[i]
     if child ~= nil then
       local child_table = trie_as_table(child)

--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -68,7 +68,7 @@ end
 ---@param byte number
 ---@return boolean
 function utils.byte_is_valid_colorchar(byte)
-  return utils.byte_is_alphanumeric(byte) or byte == ("-"):byte()
+  return utils.byte_is_alphanumeric(byte) or byte == ("-"):byte() or byte == ("_"):byte()
 end
 
 ---Count the number of character in a string


### PR DESCRIPTION
since this forked repository is used as part of the `NvChad`, so I think it would be great to be able to highlight the NvChad Base46 theme color by name, by adding the theme's color table to the `custom` option, for example

```lua

local reload_colorizer = function()
  local base_30 = require("base46").get_theme_tb "base_30"
  local base_16 = require("base46").get_theme_tb "base_16"
  require("colorizer").setup {
    user_default_options = {
      custom = vim.tbl_extend("keep", base_30, base_16),
    },
  }
end
...
-- Lazy 
{
  "NvChad/nvim-colorizer.lua",
  dependencies = "NvChad/base46",
  config = reload_colorizer,
},
```

so that we can highlight those names accordingly, it's especially useful when editing the highlight groups


![image](https://github.com/NvChad/nvim-colorizer.lua/assets/2351076/e393447f-962b-4762-bf5f-c8c92ea3289d)
