### PR TITLE
Fix/110 add names custom nonalpha chars to trie

### DIFF
--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -910,7 +910,7 @@ LUA API                                                 *colorizer.sass-lua-api*
 Functions: ~
     |cleanup| - Cleanup sass variables and watch handlers
 
-    |name_parser| - Parse the given line for sass color names
+    |parser| - Parse the given line for sass color names
  check for value in state[buf].definitions_all
 
     |update_variables| - Parse the given lines for sass variabled and add to
@@ -925,7 +925,7 @@ cleanup({bufnr})                                        *colorizer.sass.cleanup*
 
 
 
-name_parser({line}, {i}, {bufnr})                   *colorizer.sass.name_parser*
+parser({line}, {i}, {bufnr})                             *colorizer.sass.parser*
     Parse the given line for sass color names
      check for value in state[buf].definitions_all
 

--- a/doc/modules/colorizer.sass.html
+++ b/doc/modules/colorizer.sass.html
@@ -75,7 +75,7 @@
 	<td class="summary">Cleanup sass variables and watch handlers</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#name_parser">name_parser (line, i, bufnr)</a></td>
+	<td class="name" nowrap><a href="#parser">parser (line, i, bufnr)</a></td>
 	<td class="summary">Parse the given line for sass color names
  check for value in state[buf].definitions_all</td>
 	</tr>
@@ -113,8 +113,8 @@
 
 </dd>
     <dt>
-    <a name = "name_parser"></a>
-    <strong>name_parser (line, i, bufnr)</strong>
+    <a name = "parser"></a>
+    <strong>parser (line, i, bufnr)</strong>
     </dt>
     <dd>
     Parse the given line for sass color names

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -233,7 +233,7 @@ function M.parse_buffer_options(options)
     end
   end
 
-  -- https://github.com/NvChad/nvim-colorizer.lua/issues/48
+  -- https://github.com/catgoose/nvim-colorizer.lua/issues/48
   handle_alias("css", options, default)
   handle_alias("css_fn", options, default)
 

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -15,6 +15,7 @@ local parsers = {
   hsl_function = require("colorizer.parser.hsl").parser,
   rgb_function = require("colorizer.parser.rgb").parser,
   rgba_hex = require("colorizer.parser.rgba_hex").parser,
+  --  TODO: 2024-12-21 - Should this be moved into parsers module?
   sass_name = require("colorizer.sass").parser,
 }
 

--- a/lua/colorizer/parser/hsl.lua
+++ b/lua/colorizer/parser/hsl.lua
@@ -18,7 +18,7 @@ local hsl_to_rgb = require("colorizer.color").hsl_to_rgb
 --   - `prefix` (string): "hsl" or "hsla" to specify the CSS function type.
 -- @return number|nil The end index of the parsed `hsl/hsla` function within the line, or `nil` if no match was found.
 -- @return string|nil The RGB hexadecimal color (e.g., "ff0000" for red), or `nil` if parsing failed
-function M.hsl_function_parser(line, i, opts)
+function M.parser(line, i, opts)
   local min_len = #"hsla(0,0%,0%)" - 1
   local min_commas, min_spaces = 2, 2
   local pattern = "^"

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -117,6 +117,7 @@ end
 -- @return number|nil, string|nil Length of match and hex value if found.
 function M.parser(line, i, opts)
   if not names_cache.color_trie or opts.tailwind ~= names_cache.tailwind_enabled then
+    --  TODO: 2024-12-21 - Ensure that this is not being called too many times
     populate_colors(opts)
   end
 

--- a/lua/colorizer/parser/rgb.lua
+++ b/lua/colorizer/parser/rgb.lua
@@ -16,7 +16,7 @@ local count = require("colorizer.utils").count
 --   - `prefix` (string): "rgb" or "rgba" to specify the CSS function type
 -- @return number|nil The end index of the parsed `rgb/rgba` function within the line, or `nil` if parsing failed
 -- @return string|nil The RGB hexadecimal color (e.g., "ff0000" for red), or `nil` if parsing failed
-function M.rgb_function_parser(line, i, opts)
+function M.parser(line, i, opts)
   local min_len = #"rgba(0,0,0)" - 1
   local min_commas, min_spaces, min_percent = 2, 2, 3
   local pattern = "^"

--- a/lua/colorizer/sass.lua
+++ b/lua/colorizer/sass.lua
@@ -37,7 +37,7 @@ end
 ---@param i number: Index of line from where to start parsing
 ---@param bufnr number: Buffer number
 ---@return number|nil, string|nil
-function M.name_parser(line, i, bufnr)
+function M.parser(line, i, bufnr)
   local variable_name = line:match("^%$([%w_-]+)", i)
   if variable_name then
     local rgb_hex = state[bufnr].definitions_all[variable_name]

--- a/lua/colorizer/trie.lua
+++ b/lua/colorizer/trie.lua
@@ -54,11 +54,12 @@ end
 
 local total_char = 255
 local index_lookup = ffi.new("uint8_t[?]", total_char)
-local char_lookup = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+local char_lookup = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
 do
   local b = string.byte
   local extra_char = {
     [b("-")] = true,
+    [b("_")] = true,
   }
   local byte = {
     ["0"] = b("0"),

--- a/lua/colorizer/trie.lua
+++ b/lua/colorizer/trie.lua
@@ -54,13 +54,9 @@ end
 
 local total_char = 255
 local index_lookup = ffi.new("uint8_t[?]", total_char)
-local char_lookup = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
+local char_lookup = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 do
   local b = string.byte
-  local extra_char = {
-    [b("-")] = true,
-    [b("_")] = true,
-  }
   local byte = {
     ["0"] = b("0"),
     ["9"] = b("9"),
@@ -76,7 +72,6 @@ do
       index_lookup[i] = i - byte["A"] + 10
     elseif i >= byte["a"] and i <= byte["z"] then
       index_lookup[i] = i - byte["a"] + 10 + 26
-    elseif extra_char[i] then
     else
       index_lookup[i] = total_char
     end
@@ -248,6 +243,20 @@ local function trie_to_string(trie)
   return table.concat(print_trie_table(as_table), "\n")
 end
 
+local function trie_additional_chars(trie, chars)
+  if trie == nil or type(chars) ~= "string" then
+    return
+  end
+  for i = 1, #chars do
+    local char = chars:sub(i, i)
+    local char_byte = string.byte(char)
+    if index_lookup[char_byte] == total_char then
+      char_lookup = char_lookup .. char
+      index_lookup[char_byte] = total_char + 1
+    end
+  end
+end
+
 local Trie_mt = {
   __new = function(_, init)
     local trie = trie_create()
@@ -262,6 +271,7 @@ local Trie_mt = {
     longest_prefix = trie_longest_prefix,
     extend = trie_extend,
     destroy = trie_destroy,
+    additional_chars = trie_additional_chars,
   },
   __tostring = trie_to_string,
   __gc = trie_destroy,

--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -64,11 +64,11 @@ function M.byte_is_hex(byte)
   return band(byte_category[byte], category_hex) ~= 0
 end
 
---  TODO: 2024-12-21 - Is this check required?
 --- Checks if a byte is valid as a color character (alphanumeric or `-` for Tailwind colors).
 ---@param byte number The byte to check.
 ---@return boolean `true` if the byte is valid, otherwise `false`.
 function M.byte_is_valid_colorchar(byte)
+  --  TODO: 2024-12-21 - Is this check required?
   return M.byte_is_alphanumeric(byte) or byte == ("-"):byte()
 end
 

--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -64,6 +64,7 @@ function M.byte_is_hex(byte)
   return band(byte_category[byte], category_hex) ~= 0
 end
 
+--  TODO: 2024-12-21 - Is this check required?
 --- Checks if a byte is valid as a color character (alphanumeric or `-` for Tailwind colors).
 ---@param byte number The byte to check.
 ---@return boolean `true` if the byte is valid, otherwise `false`.

--- a/test/expect.lua
+++ b/test/expect.lua
@@ -6,15 +6,10 @@ local opts = {
     lua = {
       names = true,
       names_custom = {
-        -- names = "#1F4770",
-        names = "#791497",
-        cool = "#3F3347",
-        lua = "#107d3c",
-        ["notcool"] = "#ee9240",
-        redgreen = "#970000",
-        asdf = "#234311",
-        eeee = "#112238",
-        -- lua
+        red_purple = "#107dac",
+        redpurple = "#107dac",
+        green_blue = "#ee9240",
+        greenblue = "#ee9240",
       },
       -- names_custom = function()
       --   local colors = require("kanagawa.colors").setup()
@@ -25,11 +20,6 @@ local opts = {
   buftypes = { "*", "!prompt", "!popup" },
   user_commands = true,
   user_default_options = {
-    names_custom = {
-      -- names = "#1F4770",
-      names = "#1740F7",
-      lua = "#7407F1",
-    },
     names = false,
     RGB = true,
     RRGGBB = true,
@@ -68,6 +58,12 @@ White
 Extra names:
 oniViolet oniViolet2 crystalBlue springViolet1 springViolet2 springBlue
 lightBlue waveAqua2
+
+Checking for underscore:
+-- red_purple
+-- redpurple
+-- green_blue
+-- greenblue
 
 Hexadecimal:
 #RGB:

--- a/test/expect.lua
+++ b/test/expect.lua
@@ -6,10 +6,11 @@ local opts = {
     lua = {
       names = true,
       names_custom = {
-        red_purple = "#107dac",
-        redpurple = "#107dac",
-        green_blue = "#ee9240",
-        greenblue = "#ee9240",
+        red_purple = "#017dac",
+        ["red=green"] = "#3700c2",
+        ["green@blue"] = "#e9e240",
+        ["green!blue"] = "#a9e042",
+        ["green!!blue"] = "#09e392",
       },
       -- names_custom = function()
       --   local colors = require("kanagawa.colors").setup()
@@ -59,11 +60,8 @@ Extra names:
 oniViolet oniViolet2 crystalBlue springViolet1 springViolet2 springBlue
 lightBlue waveAqua2
 
-Checking for underscore:
--- red_purple
--- redpurple
--- green_blue
--- greenblue
+Additional names with non-alphanumeric characters
+red_purple red=green green@blue green!blue green!!blue
 
 Hexadecimal:
 #RGB:


### PR DESCRIPTION
- Adds `additional_chars` method to Trie metatable
- Refactors `names` parser to add '-' `additional_char` to Trie for tailwind and any non-alphanumeric chars from keys in `names_custom`