### PR TITLE
feat!: colorizer.is_buffer_attached now returns boolean.

### DIFF
--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -86,7 +86,9 @@ Functions: ~
 
     |rehighlight| - Rehighlight the buffer if colorizer is active
 
-    |is_buffer_attached| - Check if attached to a buffer
+    |get_attached_bufnr| - Get attached bufnr
+
+    |is_buffer_attached| - Check if buffer is attached to colorizer
 
     |reload_all_buffers| - Reload all of the currently active highlighted
     buffers.
@@ -134,17 +136,29 @@ rehighlight({bufnr}, {options}, {options_local}, {use_local_lines})
 
 
 
-is_buffer_attached({bufnr})                       *colorizer.is_buffer_attached*
-    Check if attached to a buffer
+get_attached_bufnr({bufnr})                       *colorizer.get_attached_bufnr*
+    Get attached bufnr
 
     Parameters: ~
 	{bufnr} -  number|nil: buffer number (0 for current)
 
     returns:~
-	number: returns bufnr if attached, otherwise -1
+	number: Returns attached bufnr. Returns -1 if buffer is not attached to
+	colorizer.
 
     See also:~
 	|colorizer.buffer.highlight|
+
+
+
+is_buffer_attached({bufnr})                       *colorizer.is_buffer_attached*
+    Check if buffer is attached to colorizer
+
+    Parameters: ~
+	{bufnr} -  number|nil: buffer number (0 for current)
+
+    returns:~
+	boolean: Returns `true` if buffer is attached to colorizer.
 
 
 
@@ -177,6 +191,9 @@ detach_from_buffer({bufnr})                       *colorizer.detach_from_buffer*
 
     Parameters: ~
 	{bufnr} -  number|nil: buffer number (0 for current)
+
+    returns:~
+	number: returns -1 if buffer is not attached, otherwise returns bufnr
 
 
 

--- a/doc/modules/colorizer.html
+++ b/doc/modules/colorizer.html
@@ -155,8 +155,12 @@ Detach
 	<td class="summary">Rehighlight the buffer if colorizer is active</td>
 	</tr>
 	<tr>
+	<td class="name" nowrap><a href="#get_attached_bufnr">get_attached_bufnr (bufnr)</a></td>
+	<td class="summary">Get attached bufnr</td>
+	</tr>
+	<tr>
 	<td class="name" nowrap><a href="#is_buffer_attached">is_buffer_attached (bufnr)</a></td>
-	<td class="summary">Check if attached to a buffer</td>
+	<td class="summary">Check if buffer is attached to colorizer</td>
 	</tr>
 	<tr>
 	<td class="name" nowrap><a href="#reload_all_buffers">reload_all_buffers ()</a></td>
@@ -251,11 +255,11 @@ Detach
 
 </dd>
     <dt>
-    <a name = "is_buffer_attached"></a>
-    <strong>is_buffer_attached (bufnr)</strong>
+    <a name = "get_attached_bufnr"></a>
+    <strong>get_attached_bufnr (bufnr)</strong>
     </dt>
     <dd>
-    Check if attached to a buffer
+    Get attached bufnr
 
 
     <h3>Parameters:</h3>
@@ -268,7 +272,7 @@ Detach
     <h3>Returns:</h3>
     <ol>
 
-        number: returns bufnr if attached, otherwise -1
+        number: Returns attached bufnr. Returns -1 if buffer is not attached to colorizer.
     </ol>
 
 
@@ -276,6 +280,31 @@ Detach
     <ul>
          <a href="../modules/colorizer.buffer.html#highlight">colorizer.buffer.highlight</a>
     </ul>
+
+
+</dd>
+    <dt>
+    <a name = "is_buffer_attached"></a>
+    <strong>is_buffer_attached (bufnr)</strong>
+    </dt>
+    <dd>
+    Check if buffer is attached to colorizer
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">bufnr</span>
+         number|nil: buffer number (0 for current)
+        </li>
+    </ul>
+
+    <h3>Returns:</h3>
+    <ol>
+
+        boolean: Returns `true` if buffer is attached to colorizer.
+    </ol>
+
+
 
 
 </dd>
@@ -354,6 +383,11 @@ Detach
         </li>
     </ul>
 
+    <h3>Returns:</h3>
+    <ol>
+
+        number: returns -1 if buffer is not attached, otherwise returns bufnr
+    </ol>
 
 
 

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -171,11 +171,11 @@ function M.rehighlight(bufnr, options, options_local, use_local_lines)
   return returns
 end
 
----Check if attached to a buffer
+---Get attached bufnr
 ---@param bufnr number|nil: buffer number (0 for current)
----@return number: returns bufnr if attached, otherwise -1
+---@return number: Returns attached bufnr. Returns -1 if buffer is not attached to colorizer.
 ---@see colorizer.buffer.highlight
-function M.is_buffer_attached(bufnr)
+function M.get_attached_bufnr(bufnr)
   if bufnr == 0 or not bufnr then
     bufnr = utils.bufme(bufnr)
   else
@@ -195,11 +195,18 @@ function M.is_buffer_attached(bufnr)
   return bufnr
 end
 
+---Check if buffer is attached to colorizer
+---@param bufnr number|nil: buffer number (0 for current)
+---@return boolean: Returns `true` if buffer is attached to colorizer.
+function M.is_buffer_attached(bufnr)
+  return M.get_attached_bufnr(bufnr) > -1
+end
+
 --- Return buffer options if buffer is attached to colorizer.
 ---@param bufnr number: Buffer number (0 for current)
 ---@return table|nil
 local function get_attached_buffer_options(bufnr)
-  local attached_bufnr = M.is_buffer_attached(bufnr)
+  local attached_bufnr = M.get_attached_bufnr(bufnr)
   if attached_bufnr > -1 then
     return colorizer_state.buffer_options[attached_bufnr]
   end
@@ -383,9 +390,10 @@ end
 
 --- Stop highlighting the current buffer.
 ---@param bufnr number|nil: buffer number (0 for current)
+---@return number: returns -1 if buffer is not attached, otherwise returns bufnr
 function M.detach_from_buffer(bufnr)
   bufnr = utils.bufme(bufnr)
-  bufnr = M.is_buffer_attached(bufnr)
+  bufnr = M.get_attached_bufnr(bufnr)
   if bufnr < 0 then
     return -1
   end
@@ -407,6 +415,7 @@ function M.detach_from_buffer(bufnr)
   end
   -- because now the buffer is not visible, so delete its information
   colorizer_state.buffer_options[bufnr] = nil
+  return bufnr
 end
 
 ---Easy to use function if you want the full setup without fine grained control.

--- a/lua/colorizer/usercmds.lua
+++ b/lua/colorizer/usercmds.lua
@@ -32,7 +32,7 @@ function M.make(cmds)
     ColorizerDetachFromBuffer = wrap("ColorizerDetachFromBuffer", c.detach_from_buffer),
     ColorizerReloadAllBuffers = wrap("ColorizerReloadAllBuffers", c.reload_all_buffers),
     ColorizerToggle = wrap("ColorizerToggle", function()
-      if c.is_buffer_attached() < 0 then
+      if not c.is_buffer_attached() then
         c.attach_to_buffer()
       else
         c.detach_from_buffer()


### PR DESCRIPTION
- `colorizer.is_buffer_attached` returns boolean.
- `colorizer.get_attached_bufnr` returns -1 if not attached.

Referencing https://github.com/catgoose/nvim-colorizer.lua/issues/57#issuecomment-2561680035