### PR TITLE
feat(names): Configure lower/camel/upper case of names highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,15 @@ library to do custom highlighting themselves.
   require("colorizer").setup({
     filetypes = { "*" },
     user_default_options = {
-      names = true, -- "Name" codes like Blue or blue
-      -- Expects a table of color name to rgb value pairs.  # is optional
+      names = true, -- "Name" codes like Blue or red
+      names_opts = { -- options for mutating/filtering names from `vim.api.nvim_get_color_map()`
+        lowercase = true, -- name:lower(), highlight `blue` and `red`
+        camelcase = true, -- name, highlight `Blue` and `Red`
+        uppercase = false, -- name:upper(), highlight `BLUE` and `RED`
+        strip_digits = false, -- ignore names with digits,
+        -- highlight `blue` and `red`, but not `blue3` and `red4`
+      },
+      -- Expects a table of color name to #RRGGBB value pairs.  # is optional
       -- Example: { cool = "#107dac", ["notcool"] = "ee9240" }
       -- Set to false|nil to disable
       names_custom = false, -- Custom names to be highlighted: table|function|false|nil
@@ -246,14 +253,15 @@ require("colorizer").setup({
 
 In `user_default_options`, there are 2 types of options
 
-1. Individual options - `names`, `RGB`, `RRGGBB`, `RRGGBBAA`, `hsl_fn`, `rgb_fn`,
-   `RRGGBBAA`, `AARRGGBB`, `tailwind`, `sass`
+1. Individual options - `names`, `names_opts`, `names_custom`, `RGB`, `RGBA`,
+   `RRGGBB`, `RRGGBBAA`, `hsl_fn`, `rgb_fn`, `RRGGBBAA`, `AARRGGBB`, `tailwind`,
+   `sass`
 
 1. Alias options - `css`, `css_fn`
 
 If `css_fn` is true, then `hsl_fn`, `rgb_fn` becomes `true`
 
-If `css` is true, then `names`, `RGB`, `RRGGBB`, `RRGGBBAA`, `hsl_fn`, `rgb_fn`
+If `css` is true, then `names`, `RGB`, `RGBA`, `RRGGBB`, `RRGGBBAA`, `hsl_fn`, `rgb_fn`
 becomes `true`
 
 These options have a priority, Individual options have the highest priority,
@@ -261,7 +269,8 @@ then alias options
 
 For alias, `css_fn` has more priority over `css`
 
-e.g: Here `RGB`, `RRGGBB`, `RRGGBBAA`, `hsl_fn`, `rgb_fn` is enabled but not `names`
+e.g: Here `RGB`, `RGBA`, `RRGGBB`, `RRGGBBAA`, `AARRGGBB`, `hsl_fn`, `rgb_fn` is
+enabled but not `names`
 
 ```lua
 require("colorizer").setup({
@@ -272,7 +281,8 @@ require("colorizer").setup({
 })
 ```
 
-e.g: Here `names`, `RGB`, `RRGGBB`, `RRGGBBAA` is enabled but not `rgb_fn` and `hsl_fn`
+e.g: Here `names`, `RGB`, `RGBA`, `RRGGBB`, `RRGGBBAA`, `AARRGGBB` is enabled but
+not `rgb_fn` and `hsl_fn`
 
 ```lua
 require("colorizer").setup({

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ library to do custom highlighting themselves.
   require("colorizer").setup({
     filetypes = { "*" },
     user_default_options = {
-      names = true, -- "Name" codes like Blue or red
-      names_opts = { -- options for mutating/filtering names from `vim.api.nvim_get_color_map()`
+      names = true, -- "Name" codes like Blue or red.  Added from `vim.api.nvim_get_color_map()`
+      names_opts = { -- options for mutating/filtering names.
         lowercase = true, -- name:lower(), highlight `blue` and `red`
         camelcase = true, -- name, highlight `Blue` and `Red`
         uppercase = false, -- name:upper(), highlight `BLUE` and `RED`
@@ -133,7 +133,7 @@ library to do custom highlighting themselves.
       },
       -- Expects a table of color name to #RRGGBB value pairs.  # is optional
       -- Example: { cool = "#107dac", ["notcool"] = "ee9240" }
-      -- Set to false|nil to disable
+      -- Set to false|nil to disable, for example when setting filetype options
       names_custom = false, -- Custom names to be highlighted: table|function|false|nil
       RGB = true, -- #RGB hex codes
       RGBA = true, -- #RGBA hex codes
@@ -142,7 +142,8 @@ library to do custom highlighting themselves.
       AARRGGBB = false, -- 0xAARRGGBB hex codes
       rgb_fn = false, -- CSS rgb() and rgba() functions
       hsl_fn = false, -- CSS hsl() and hsla() functions
-      css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
+      css = false, -- Enable all CSS *features*:
+      -- names, RGB, RGBA, RRGGBB, RRGGBBAA, AARRGGBB, rgb_fn, hsl_fn
       css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
       -- Highlighting mode.  'background'|'foreground'|'virtualtext'
       mode = "background", -- Set the display mode

--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -569,13 +569,15 @@ user_default_options                     *colorizer.config.user_default_options*
 
 
     Fields: ~
+	{names} -  boolean: Enables named colors (e.g., "Blue").
+	{names_opts} -  table: Names options for customizing casing, digit
+	stripping, etc
+	{names_custom} -  table|function|false|nil: Custom color name to RGB
+	value mappings
+ should return a table of color names to RGB value pairs
 	{RGB} -  boolean: Enables `#RGB` hex codes.
 	{RGBA} -  boolean: Enables `#RGBA` hex codes.
 	{RRGGBB} -  boolean: Enables `#RRGGBB` hex codes.
-	{names} -  boolean: Enables named colors (e.g., "Blue").
-	{names_custom} -  table|function|nil: Extra color name to RGB value
-	mappings
- should return a table of color names to RGB value pairs
 	{RRGGBBAA} -  boolean: Enables `#RRGGBBAA` hex codes.
 	{AARRGGBB} -  boolean: Enables `0xAARRGGBB` hex codes.
 	{rgb_fn} -  boolean: Enables CSS `rgb()` and `rgba()` functions.
@@ -617,11 +619,14 @@ opts                                                     *colorizer.config.opts*
 	{filetypes} -  table A list of file types where colorizer should be
 	enabled. Use `"*"` for all file types.
 	{user_default_options} -  table Default options for color handling.
+   - `names` (boolean): Enables named color codes like `"Blue"`.
+   - `names_opts` (table): Names options for customizing casing, digit
+     stripping, etc
+   - `names_custom` (table|function|false|nil): Custom color name to RGB value
+     mappings
    - `RGB` (boolean): Enables support for `#RGB` hex codes.
    - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
    - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
-   - `names` (boolean): Enables named color codes like `"Blue"`.
-   - `names_custom` (table|function|nil): Extra color name to RGB value mappings
    - `RRGGBBAA` (boolean): Enables support for `#RRGGBBAA` hex codes.
    - `AARRGGBB` (boolean): Enables support for `0xAARRGGBB` hex codes.
    - `rgb_fn` (boolean): Enables CSS `rgb()` and `rgba()` functions.
@@ -682,7 +687,7 @@ reset_cache()                                    *colorizer.matcher.reset_cache*
 
 
 
-make({options})                                         *colorizer.matcher.make*
+make({opts})                                            *colorizer.matcher.make*
     Parse the given options and return a function with enabled parsers.
 
     if no parsers enabled then return false
@@ -690,7 +695,7 @@ make({options})                                         *colorizer.matcher.make*
 
 
     Parameters: ~
-	{options} -  table: options created in `colorizer.setup`
+	{opts} -  table: options created in `colorizer.setup`
 
     returns:~
 	function or boolean: function which will just parse the line for enabled
@@ -772,12 +777,12 @@ parser({line}, {i}, {opts})                      *colorizer.parser.names.parser*
     Parses a line to identify color names.
 
     Parameters: ~
-	{line} -  string The text line to parse.
-	{i} -  number The index to start parsing from.
-	{opts} -  table Parsing options.
+	{line} -  string: The text line to parse.
+	{i} -  number: The index to start parsing from.
+	{opts} -  table: Parsing options.
 
     returns:~
-	number or nil, string or nil Length of match and hex value if found.
+	number or nil, string or nil: Length of match and hex value if found.
 
 
 

--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -453,6 +453,8 @@ Provides configuration options and utilities for setting up colorizer.
 LUA API                                               *colorizer.config-lua-api*
 
 Functions: ~
+    |reset_cache| - Reset the cache for buffer options.
+
     |set_bo_value| - Set options for a specific buffer or file type.
 
     |apply_alias_options| - Parse and apply alias options to the user options.
@@ -470,6 +472,14 @@ Tables: ~
     |options| - Options for colorizer that were passed in to setup function
 
     |opts| - Configuration options for the `setup` function.
+
+
+reset_cache()                                     *colorizer.config.reset_cache*
+    Reset the cache for buffer options.
+
+     Called from colorizer.setup
+
+
 
 
 set_bo_value({bo_type}, {value}, {options})      *colorizer.config.set_bo_value*
@@ -560,6 +570,7 @@ user_default_options                     *colorizer.config.user_default_options*
 
     Fields: ~
 	{RGB} -  boolean: Enables `#RGB` hex codes.
+	{RGBA} -  boolean: Enables `#RGBA` hex codes.
 	{RRGGBB} -  boolean: Enables `#RRGGBB` hex codes.
 	{names} -  boolean: Enables named colors (e.g., "Blue").
 	{names_custom} -  table|function|nil: Extra color name to RGB value
@@ -607,6 +618,7 @@ opts                                                     *colorizer.config.opts*
 	enabled. Use `"*"` for all file types.
 	{user_default_options} -  table Default options for color handling.
    - `RGB` (boolean): Enables support for `#RGB` hex codes.
+   - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
    - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
    - `names` (boolean): Enables named color codes like `"Blue"`.
    - `names_custom` (table|function|nil): Extra color name to RGB value mappings
@@ -658,10 +670,16 @@ Manages matching and parsing of color patterns in buffers.
 LUA API                                              *colorizer.matcher-lua-api*
 
 Functions: ~
+    |reset_cache| - Reset matcher cache
+ Called from colorizer.setup
+
     |make| - Parse the given options and return a function with enabled parsers.
 
-    |reset_cache| - Reset the cache of matchers
-Called from colorizer.setup
+
+reset_cache()                                    *colorizer.matcher.reset_cache*
+    Reset matcher cache
+     Called from colorizer.setup
+
 
 
 make({options})                                         *colorizer.matcher.make*
@@ -677,12 +695,6 @@ make({options})                                         *colorizer.matcher.make*
     returns:~
 	function or boolean: function which will just parse the line for enabled
 	parsers
-
-
-
-reset_cache()                                    *colorizer.matcher.reset_cache*
-    Reset the cache of matchers
-    Called from colorizer.setup
 
 
 
@@ -743,9 +755,17 @@ text.
 LUA API                                         *colorizer.parser.names-lua-api*
 
 Functions: ~
+    |reset_cache| - Reset the color names cache.
+
     |parser| - Parses a line to identify color names.
 
-    |reset_cache| - Resets the color names cache.
+
+reset_cache()                               *colorizer.parser.names.reset_cache*
+    Reset the color names cache.
+
+     Called from colorizer.setup
+
+
 
 
 parser({line}, {i}, {opts})                      *colorizer.parser.names.parser*
@@ -758,14 +778,6 @@ parser({line}, {i}, {opts})                      *colorizer.parser.names.parser*
 
     returns:~
 	number or nil, string or nil Length of match and hex value if found.
-
-
-
-reset_cache()                               *colorizer.parser.names.reset_cache*
-    Resets the color names cache.
-
-    Called from colorizer.setup
-
 
 
 

--- a/doc/modules/colorizer.config.html
+++ b/doc/modules/colorizer.config.html
@@ -286,6 +286,16 @@
 
     <h3>Fields:</h3>
     <ul>
+        <li><span class="parameter">names</span>
+         boolean: Enables named colors (e.g., "Blue").
+        </li>
+        <li><span class="parameter">names_opts</span>
+         table: Names options for customizing casing, digit stripping, etc
+        </li>
+        <li><span class="parameter">names_custom</span>
+         table|function|false|nil: Custom color name to RGB value mappings
+ should return a table of color names to RGB value pairs
+        </li>
         <li><span class="parameter">RGB</span>
          boolean: Enables `#RGB` hex codes.
         </li>
@@ -294,13 +304,6 @@
         </li>
         <li><span class="parameter">RRGGBB</span>
          boolean: Enables `#RRGGBB` hex codes.
-        </li>
-        <li><span class="parameter">names</span>
-         boolean: Enables named colors (e.g., "Blue").
-        </li>
-        <li><span class="parameter">names_custom</span>
-         table|function|nil: Extra color name to RGB value mappings
- should return a table of color names to RGB value pairs
         </li>
         <li><span class="parameter">RRGGBBAA</span>
          boolean: Enables `#RRGGBBAA` hex codes.
@@ -401,11 +404,12 @@
         </li>
         <li><span class="parameter">user_default_options</span>
          table Default options for color handling.
+   - `names` (boolean): Enables named color codes like `"Blue"`.
+   - `names_opts` (table): Names options for customizing casing, digit stripping, etc
+   - `names_custom` (table|function|false|nil): Custom color name to RGB value mappings
    - `RGB` (boolean): Enables support for `#RGB` hex codes.
    - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
    - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
-   - `names` (boolean): Enables named color codes like `"Blue"`.
-   - `names_custom` (table|function|nil): Extra color name to RGB value mappings
    - `RRGGBBAA` (boolean): Enables support for `#RRGGBBAA` hex codes.
    - `AARRGGBB` (boolean): Enables support for `0xAARRGGBB` hex codes.
    - `rgb_fn` (boolean): Enables CSS `rgb()` and `rgba()` functions.

--- a/doc/modules/colorizer.config.html
+++ b/doc/modules/colorizer.config.html
@@ -69,6 +69,10 @@
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
+	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
+	<td class="summary">Reset the cache for buffer options.</td>
+	</tr>
+	<tr>
 	<td class="name" nowrap><a href="#set_bo_value">set_bo_value (bo_type, value, options)</a></td>
 	<td class="summary">Set options for a specific buffer or file type.</td>
 	</tr>
@@ -112,6 +116,21 @@
     <h2 class="section-header "><a name="Functions"></a>Functions</h2>
 
     <dl class="function">
+    <dt>
+    <a name = "reset_cache"></a>
+    <strong>reset_cache ()</strong>
+    </dt>
+    <dd>
+    Reset the cache for buffer options.
+ Called from colorizer.setup
+
+
+
+
+
+
+
+</dd>
     <dt>
     <a name = "set_bo_value"></a>
     <strong>set_bo_value (bo_type, value, options)</strong>
@@ -270,6 +289,9 @@
         <li><span class="parameter">RGB</span>
          boolean: Enables `#RGB` hex codes.
         </li>
+        <li><span class="parameter">RGBA</span>
+         boolean: Enables `#RGBA` hex codes.
+        </li>
         <li><span class="parameter">RRGGBB</span>
          boolean: Enables `#RRGGBB` hex codes.
         </li>
@@ -380,6 +402,7 @@
         <li><span class="parameter">user_default_options</span>
          table Default options for color handling.
    - `RGB` (boolean): Enables support for `#RGB` hex codes.
+   - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
    - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
    - `names` (boolean): Enables named color codes like `"Blue"`.
    - `names_custom` (table|function|nil): Extra color name to RGB value mappings

--- a/doc/modules/colorizer.matcher.html
+++ b/doc/modules/colorizer.matcher.html
@@ -76,7 +76,7 @@
  Called from colorizer.setup</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#make">make (options)</a></td>
+	<td class="name" nowrap><a href="#make">make (opts)</a></td>
 	<td class="summary">Parse the given options and return a function with enabled parsers.</td>
 	</tr>
 </table>
@@ -105,7 +105,7 @@
 </dd>
     <dt>
     <a name = "make"></a>
-    <strong>make (options)</strong>
+    <strong>make (opts)</strong>
     </dt>
     <dd>
     Parse the given options and return a function with enabled parsers.
@@ -115,7 +115,7 @@ Do not try make the function again if it is present in the cache
 
     <h3>Parameters:</h3>
     <ul>
-        <li><span class="parameter">options</span>
+        <li><span class="parameter">opts</span>
          table: options created in `colorizer.setup`
         </li>
     </ul>

--- a/doc/modules/colorizer.matcher.html
+++ b/doc/modules/colorizer.matcher.html
@@ -71,13 +71,13 @@
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
-	<td class="name" nowrap><a href="#make">make (options)</a></td>
-	<td class="summary">Parse the given options and return a function with enabled parsers.</td>
+	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
+	<td class="summary">Reset matcher cache
+ Called from colorizer.setup</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
-	<td class="summary">Reset the cache of matchers
-Called from colorizer.setup</td>
+	<td class="name" nowrap><a href="#make">make (options)</a></td>
+	<td class="summary">Parse the given options and return a function with enabled parsers.</td>
 	</tr>
 </table>
 
@@ -88,6 +88,21 @@ Called from colorizer.setup</td>
     <h2 class="section-header "><a name="Functions"></a>Functions</h2>
 
     <dl class="function">
+    <dt>
+    <a name = "reset_cache"></a>
+    <strong>reset_cache ()</strong>
+    </dt>
+    <dd>
+    Reset matcher cache
+ Called from colorizer.setup
+
+
+
+
+
+
+
+</dd>
     <dt>
     <a name = "make"></a>
     <strong>make (options)</strong>
@@ -110,21 +125,6 @@ Do not try make the function again if it is present in the cache
 
         function|boolean: function which will just parse the line for enabled parsers
     </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "reset_cache"></a>
-    <strong>reset_cache ()</strong>
-    </dt>
-    <dd>
-    Reset the cache of matchers
-Called from colorizer.setup
-
-
-
 
 
 

--- a/doc/modules/colorizer.parser.names.html
+++ b/doc/modules/colorizer.parser.names.html
@@ -70,12 +70,12 @@
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
-	<td class="name" nowrap><a href="#parser">parser (line, i, opts)</a></td>
-	<td class="summary">Parses a line to identify color names.</td>
+	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
+	<td class="summary">Reset the color names cache.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
-	<td class="summary">Resets the color names cache.</td>
+	<td class="name" nowrap><a href="#parser">parser (line, i, opts)</a></td>
+	<td class="summary">Parses a line to identify color names.</td>
 	</tr>
 </table>
 
@@ -86,6 +86,21 @@
     <h2 class="section-header "><a name="Functions"></a>Functions</h2>
 
     <dl class="function">
+    <dt>
+    <a name = "reset_cache"></a>
+    <strong>reset_cache ()</strong>
+    </dt>
+    <dd>
+    Reset the color names cache.
+ Called from colorizer.setup
+
+
+
+
+
+
+
+</dd>
     <dt>
     <a name = "parser"></a>
     <strong>parser (line, i, opts)</strong>
@@ -112,21 +127,6 @@
 
         number|nil, string|nil Length of match and hex value if found.
     </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "reset_cache"></a>
-    <strong>reset_cache ()</strong>
-    </dt>
-    <dd>
-    Resets the color names cache.
-Called from colorizer.setup
-
-
-
 
 
 

--- a/doc/modules/colorizer.parser.names.html
+++ b/doc/modules/colorizer.parser.names.html
@@ -112,20 +112,20 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">line</span>
-         string The text line to parse.
+         string: The text line to parse.
         </li>
         <li><span class="parameter">i</span>
-         number The index to start parsing from.
+         number: The index to start parsing from.
         </li>
         <li><span class="parameter">opts</span>
-         table Parsing options.
+         table: Parsing options.
         </li>
     </ul>
 
     <h3>Returns:</h3>
     <ol>
 
-        number|nil, string|nil Length of match and hex value if found.
+        number|nil, string|nil: Length of match and hex value if found.
     </ol>
 
 

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -44,12 +44,13 @@ local plugin_user_default_options = {
 -- **Option Priority**: Individual options have higher priority than aliases.
 -- If both `css` and `css_fn` are true, `css_fn` has more priority over `css`.
 -- @table user_default_options
+-- @field names boolean: Enables named colors (e.g., "Blue").
+-- @field names_opts table: Names options for customizing casing, digit stripping, etc
+-- @field names_custom table|function|false|nil: Custom color name to RGB value mappings
+-- should return a table of color names to RGB value pairs
 -- @field RGB boolean: Enables `#RGB` hex codes.
 -- @field RGBA boolean: Enables `#RGBA` hex codes.
 -- @field RRGGBB boolean: Enables `#RRGGBB` hex codes.
--- @field names boolean: Enables named colors (e.g., "Blue").
--- @field names_custom table|function|false|nil: Custom color name to RGB value mappings
--- should return a table of color names to RGB value pairs
 -- @field RRGGBBAA boolean: Enables `#RRGGBBAA` hex codes.
 -- @field AARRGGBB boolean: Enables `0xAARRGGBB` hex codes.
 -- @field rgb_fn boolean: Enables CSS `rgb()` and `rgba()` functions.
@@ -141,11 +142,12 @@ end
 -- @table opts
 -- @field filetypes table A list of file types where colorizer should be enabled. Use `"*"` for all file types.
 -- @field user_default_options table Default options for color handling.
+--   - `names` (boolean): Enables named color codes like `"Blue"`.
+--   - `names_opts` (table): Names options for customizing casing, digit stripping, etc
+--   - `names_custom` (table|function|false|nil): Custom color name to RGB value mappings
 --   - `RGB` (boolean): Enables support for `#RGB` hex codes.
 --   - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
 --   - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
---   - `names` (boolean): Enables named color codes like `"Blue"`.
---   - `names_custom` (table|function|false|nil): Custom color name to RGB value mappings
 --   - `RRGGBBAA` (boolean): Enables support for `#RRGGBBAA` hex codes.
 --   - `AARRGGBB` (boolean): Enables support for `0xAARRGGBB` hex codes.
 --   - `rgb_fn` (boolean): Enables CSS `rgb()` and `rgba()` functions.

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -39,6 +39,7 @@ local plugin_user_default_options = {
 -- If both `css` and `css_fn` are true, `css_fn` has more priority over `css`.
 -- @table user_default_options
 -- @field RGB boolean: Enables `#RGB` hex codes.
+-- @field RGBA boolean: Enables `#RGBA` hex codes.
 -- @field RRGGBB boolean: Enables `#RRGGBB` hex codes.
 -- @field names boolean: Enables named colors (e.g., "Blue").
 -- @field names_custom table|function|nil: Extra color name to RGB value mappings
@@ -66,7 +67,6 @@ local plugin_user_default_options = {
 --@field filetypes
 --@field buftypes
 M.options = {}
-
 local function init_options()
   M.options = {
     -- setup options
@@ -80,8 +80,15 @@ local function init_options()
   }
 end
 
--- State for managing buffer and filetype-specific options
-local options_cache = { buftype = {}, filetype = {} }
+local options_cache
+--- Reset the cache for buffer options.
+-- Called from colorizer.setup
+function M.reset_cache()
+  options_cache = { buftype = {}, filetype = {} }
+end
+do
+  M.reset_cache()
+end
 
 --- Set options for a specific buffer or file type.
 ---@param bo_type 'buftype'|'filetype': The type of buffer option
@@ -129,6 +136,7 @@ end
 -- @field filetypes table A list of file types where colorizer should be enabled. Use `"*"` for all file types.
 -- @field user_default_options table Default options for color handling.
 --   - `RGB` (boolean): Enables support for `#RGB` hex codes.
+--   - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
 --   - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
 --   - `names` (boolean): Enables named color codes like `"Blue"`.
 --   - `names_custom` (table|function|nil): Extra color name to RGB value mappings
@@ -184,10 +192,6 @@ end
 function M.get_bo_options(bo_type, buftype, filetype)
   local fo, bo = options_cache[bo_type][filetype], options_cache[bo_type][buftype]
   return fo or bo
-end
-
-function M.reset_cache()
-  options_cache = { buftype = {}, filetype = {} }
 end
 
 return M

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -5,6 +5,12 @@ local M = {}
 --- Defaults for colorizer options
 local plugin_user_default_options = {
   names = true,
+  names_opts = {
+    lowercase = true,
+    camelcase = true,
+    uppercase = false,
+    strip_digits = false,
+  },
   names_custom = false,
   RGB = true,
   RGBA = true,
@@ -42,7 +48,7 @@ local plugin_user_default_options = {
 -- @field RGBA boolean: Enables `#RGBA` hex codes.
 -- @field RRGGBB boolean: Enables `#RRGGBB` hex codes.
 -- @field names boolean: Enables named colors (e.g., "Blue").
--- @field names_custom table|function|nil: Extra color name to RGB value mappings
+-- @field names_custom table|function|false|nil: Custom color name to RGB value mappings
 -- should return a table of color names to RGB value pairs
 -- @field RRGGBBAA boolean: Enables `#RRGGBBAA` hex codes.
 -- @field AARRGGBB boolean: Enables `0xAARRGGBB` hex codes.
@@ -139,7 +145,7 @@ end
 --   - `RGBA` (boolean): Enables support for `#RGBA` hex codes.
 --   - `RRGGBB` (boolean): Enables support for `#RRGGBB` hex codes.
 --   - `names` (boolean): Enables named color codes like `"Blue"`.
---   - `names_custom` (table|function|nil): Extra color name to RGB value mappings
+--   - `names_custom` (table|function|false|nil): Custom color name to RGB value mappings
 --   - `RRGGBBAA` (boolean): Enables support for `#RRGGBBAA` hex codes.
 --   - `AARRGGBB` (boolean): Enables support for `0xAARRGGBB` hex codes.
 --   - `rgb_fn` (boolean): Enables CSS `rgb()` and `rgba()` functions.

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -67,7 +67,16 @@ local function compile(matchers, matchers_trie)
   return parse_fn
 end
 
-local matcher_cache = {}
+local matcher_cache
+---Reset matcher cache
+-- Called from colorizer.setup
+function M.reset_cache()
+  matcher_cache = {}
+end
+do
+  M.reset_cache()
+end
+
 ---Parse the given options and return a function with enabled parsers.
 --if no parsers enabled then return false
 --Do not try make the function again if it is present in the cache
@@ -179,12 +188,6 @@ function M.make(options)
   matcher_cache[matcher_key] = loop_parse_fn
 
   return loop_parse_fn
-end
-
----Reset the cache of matchers
----Called from colorizer.setup
-function M.reset_cache()
-  matcher_cache = {}
 end
 
 return M

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -80,41 +80,49 @@ end
 ---Parse the given options and return a function with enabled parsers.
 --if no parsers enabled then return false
 --Do not try make the function again if it is present in the cache
----@param options table: options created in `colorizer.setup`
+---@param opts table: options created in `colorizer.setup`
 ---@return function|boolean: function which will just parse the line for enabled parsers
-function M.make(options)
-  if not options then
+function M.make(opts)
+  if not opts then
     return false
   end
 
-  local enable_names = options.names
-  local enable_names_custom = options.names_custom
-  local enable_sass = options.sass and options.sass.enable
-  local enable_tailwind = options.tailwind
-  local enable_RGB = options.RGB
-  local enable_RGBA = options.RGBA
-  local enable_RRGGBB = options.RRGGBB
-  local enable_RRGGBBAA = options.RRGGBBAA
-  local enable_AARRGGBB = options.AARRGGBB
-  local enable_rgb = options.rgb_fn
-  local enable_hsl = options.hsl_fn
+  local enable_names = opts.names
+  local enable_names_lowercase = opts.names_opts and opts.names_opts.lowercase
+  local enable_names_camelcase = opts.names_opts and opts.names_opts.camelcase
+  local enable_names_uppercase = opts.names_opts and opts.names_opts.uppercase
+  local enable_names_strip_digits = opts.names_opts and opts.names_opts.strip_digits
+  local enable_names_custom = opts.names_custom
+  local enable_sass = opts.sass and opts.sass.enable
+  local enable_tailwind = opts.tailwind
+  local enable_RGB = opts.RGB
+  local enable_RGBA = opts.RGBA
+  local enable_RRGGBB = opts.RRGGBB
+  local enable_RRGGBBAA = opts.RRGGBBAA
+  local enable_AARRGGBB = opts.AARRGGBB
+  local enable_rgb = opts.rgb_fn
+  local enable_hsl = opts.hsl_fn
 
   -- Rather than use bit.lshift or calculate 2^x, use precalculated values to
   -- create unique bitmask
   local matcher_key = 0
     + (enable_names and 1 or 0)
-    + (enable_names_custom and 2 or 0)
-    + (enable_RGB and 4 or 0)
-    + (enable_RGBA and 8 or 0)
-    + (enable_RRGGBB and 16 or 0)
-    + (enable_RRGGBBAA and 32 or 0)
-    + (enable_AARRGGBB and 64 or 0)
-    + (enable_rgb and 128 or 0)
-    + (enable_hsl and 256 or 0)
-    + ((enable_tailwind == true or enable_tailwind == "normal") and 512 or 0)
-    + (enable_tailwind == "lsp" and 1024 or 0)
-    + (enable_tailwind == "both" and 2048 or 0)
-    + (enable_sass and 4096 or 0)
+    + (enable_names_lowercase and 2 or 0)
+    + (enable_names_camelcase and 4 or 0)
+    + (enable_names_uppercase and 8 or 0)
+    + (enable_names_strip_digits and 16 or 0)
+    + (enable_names_custom and 32 or 0)
+    + (enable_RGB and 64 or 0)
+    + (enable_RGBA and 128 or 0)
+    + (enable_RRGGBB and 256 or 0)
+    + (enable_RRGGBBAA and 512 or 0)
+    + (enable_AARRGGBB and 1024 or 0)
+    + (enable_rgb and 2048 or 0)
+    + (enable_hsl and 4096 or 0)
+    + ((enable_tailwind == true or enable_tailwind == "normal") and 8192 or 0)
+    + (enable_tailwind == "lsp" and 16384 or 0)
+    + (enable_tailwind == "both" and 32768 or 0)
+    + (enable_sass and 65536 or 0)
 
   if matcher_key == 0 then
     return false
@@ -128,18 +136,25 @@ function M.make(options)
   local matchers = {}
   local matchers_prefix = {}
 
-  if enable_names then
+  if enable_names or enable_names_custom or enable_tailwind then
     matchers.color_name_parser = matchers.color_name_parser or {}
-    matchers.color_name_parser.color_names = enable_names
+    if enable_names then
+      matchers.color_name_parser.color_names = enable_names
+      matchers.color_name_parser.color_names_opts = {
+        lowercase = enable_names_lowercase,
+        camelcase = enable_names_camelcase,
+        uppercase = enable_names_uppercase,
+        strip_digits = enable_names_strip_digits,
+      }
+    end
+    if enable_names_custom then
+      matchers.color_name_parser.names_custom = enable_names_custom
+    end
+    if enable_tailwind then
+      matchers.color_name_parser.tailwind = enable_tailwind
+    end
   end
-  if enable_names_custom then
-    matchers.color_name_parser = matchers.color_name_parser or {}
-    matchers.color_name_parser.names_custom = enable_names_custom
-  end
-  if enable_tailwind then
-    matchers.color_name_parser = matchers.color_name_parser or {}
-    matchers.color_name_parser.tailwind = enable_tailwind
-  end
+
   if enable_sass then
     matchers.sass_name_parser = true
   end

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -9,14 +9,22 @@ local utils = require("colorizer.utils")
 local tohex = require("bit").tohex
 local min, max = math.min, math.max
 
-local names_cache = {
-  color_map = {},
-  color_trie = nil,
-  color_name_minlen = nil,
-  color_name_maxlen = nil,
-  color_name_settings = { lowercase = true, strip_digits = false },
-  tailwind_enabled = false,
-}
+local names_cache
+---Reset the color names cache.
+-- Called from colorizer.setup
+function M.reset_cache()
+  names_cache = {
+    color_map = {},
+    color_trie = nil,
+    color_name_minlen = nil,
+    color_name_maxlen = nil,
+    color_name_settings = { lowercase = true, strip_digits = true },
+    tailwind_enabled = false,
+  }
+end
+do
+  M.reset_cache()
+end
 
 --- Internal function to add a color to the Trie and map.
 -- @param name string The color name.
@@ -103,6 +111,7 @@ end
 
 --- Handles Vim's color map and adds colors to the Trie and map.
 local function handle_names()
+  vim.print("names")
   for name, value in pairs(vim.api.nvim_get_color_map()) do
     if not (names_cache.color_name_settings.strip_digits and name:match("%d+$")) then
       local rgb_hex = tohex(value, 6)
@@ -164,19 +173,6 @@ function M.parser(line, i, opts)
     end
     return #prefix, names_cache.color_map[prefix]
   end
-end
-
----Resets the color names cache.
----Called from colorizer.setup
-function M.reset_cache()
-  names_cache = {
-    color_map = {},
-    color_trie = nil,
-    color_name_minlen = nil,
-    color_name_maxlen = nil,
-    color_name_settings = { lowercase = true, strip_digits = false },
-    tailwind_enabled = false,
-  }
 end
 
 return M

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -151,10 +151,10 @@ local function populate_colors(opts)
 end
 
 --- Parses a line to identify color names.
--- @param line string The text line to parse.
--- @param i number The index to start parsing from.
--- @param opts table Parsing options.
--- @return number|nil, string|nil Length of match and hex value if found.
+-- @param line string: The text line to parse.
+-- @param i number: The index to start parsing from.
+-- @param opts table: Parsing options.
+-- @return number|nil, string|nil: Length of match and hex value if found.
 function M.parser(line, i, opts)
   if not names_cache.color_trie or opts.tailwind ~= names_cache.tailwind_enabled then
     --  TODO: 2024-12-21 - Ensure that this is not being called too many times

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -18,7 +18,6 @@ function M.reset_cache()
     color_trie = nil,
     color_name_minlen = nil,
     color_name_maxlen = nil,
-    color_name_settings = { lowercase = true, strip_digits = true },
     tailwind_enabled = false,
   }
 end
@@ -110,14 +109,18 @@ local function handle_tailwind()
 end
 
 --- Handles Vim's color map and adds colors to the Trie and map.
-local function handle_names()
-  vim.print("names")
+local function handle_names(opts)
   for name, value in pairs(vim.api.nvim_get_color_map()) do
-    if not (names_cache.color_name_settings.strip_digits and name:match("%d+$")) then
+    if not (opts.strip_digits and name:match("%d+$")) then
       local rgb_hex = tohex(value, 6)
-      add_color(name, rgb_hex)
-      if names_cache.color_name_settings.lowercase then
+      if opts.lowercase then
         add_color(name:lower(), rgb_hex)
+      end
+      if opts.camelcase then
+        add_color(name, rgb_hex)
+      end
+      if opts.uppercase then
+        add_color(name:upper(), rgb_hex)
       end
     end
   end
@@ -132,7 +135,7 @@ local function populate_colors(opts)
 
   -- Add Vim's color map
   if opts.color_names then
-    handle_names()
+    handle_names(opts.color_names_opts)
   end
 
   -- Add Tailwind colors

--- a/lua/colorizer/tailwind_colors.lua
+++ b/lua/colorizer/tailwind_colors.lua
@@ -1,6 +1,5 @@
 -- Tailwind colors
 return {
-  -- https://github.com/tailwindlabs/tailwindcss/raw/master/src/corePlugins.js
   prefixes = {
     "accent",
     "bg",
@@ -24,7 +23,6 @@ return {
     "ring",
     "ring-offset",
   },
-  -- Generated using https://github.com/tailwindlabs/tailwindcss/raw/master/src/public/colors.js
   colors = {
     ["black"] = "000",
     ["white"] = "fff",

--- a/test/expect.lua
+++ b/test/expect.lua
@@ -6,7 +6,7 @@ local opts = {
     lua = {
       names = true,
       names_opts = {
-        strip_digits = false,
+        -- strip_digits = false,
       },
       names_custom = {
         one_two = "#017dac",
@@ -24,8 +24,8 @@ local opts = {
     names_opts = {
       lowercase = true,
       camelcase = true,
-      uppercase = true,
-      strip_digits = true,
+      uppercase = false,
+      strip_digits = false,
     },
     names_custom = function()
       local colors = require("kanagawa.colors").setup()

--- a/test/expect.lua
+++ b/test/expect.lua
@@ -5,6 +5,9 @@ local opts = {
     "!dashboard",
     lua = {
       names = true,
+      names_opts = {
+        strip_digits = false,
+      },
       names_custom = {
         one_two = "#017dac",
         ["three=four"] = "#3700c2",
@@ -18,6 +21,12 @@ local opts = {
   user_commands = true,
   user_default_options = {
     names = false,
+    names_opts = {
+      lowercase = true,
+      camelcase = true,
+      uppercase = true,
+      strip_digits = true,
+    },
     names_custom = function()
       local colors = require("kanagawa.colors").setup()
       return colors.palette
@@ -55,6 +64,11 @@ lightcoral lightcyan lemonchiffon papayawhip peachpuff
 blue gray lightblue gray100 white gold blue
 Blue LightBlue Gray100 White
 White
+
+Names options: casing, strip digits
+deepskyblue deepskyblue1
+DeepSkyBlue DeepSkyBlue2
+DEEPSKYBLUE DEEPSKYBLUE3
 
 Extra names:
 oniViolet oniViolet2 crystalBlue springViolet1 springViolet2 springBlue


### PR DESCRIPTION
- Adds configuration key to customize highlighting lowercase, camelcase, and uppercase of names highlights
- Also allows only adding `names` with no digits

Adding lowercase version and stripping digits were already in the code, but not configurable

New plugin defaults for `user_default_options`:

```lua
--- Defaults for colorizer options
user_default_options = {
  names = true,
  names_opts = {
    lowercase = true,
    camelcase = true,
    uppercase = false,
    strip_digits = false,
  },
  names_custom = false,
  RGB = true,
  RGBA = true,
  RRGGBB = true,
  RRGGBBAA = false,
  AARRGGBB = false,
  rgb_fn = false,
  hsl_fn = false,
  css = false,
  css_fn = false,
  mode = "background",
  tailwind = false,
  sass = { enable = false, parsers = { css = true } },
  virtualtext = "■",
  virtualtext_inline = false,
  virtualtext_mode = "foreground",
  always_update = false,
}
```

The default reflect the old behavior as my aim is to not break configs.

Closes #84 