### PR TITLE
fix: "rehighlight" function import

### DIFF
--- a/lua/colorizer/sass.lua
+++ b/lua/colorizer/sass.lua
@@ -207,7 +207,7 @@ local function sass_parse_lines(bufnr, line_start, content, name)
                       cc = nil
                     end
 
-                    require("colorizer.buffer").rehighlight(
+                    require("colorizer").rehighlight(
                       bufnr,
                       state[bufnr].options,
                       state[bufnr].local_options,


### PR DESCRIPTION
Hi!

Seems like import hasn't been updated after `rehighlight` function was moved.

Error example:
```
Error executing vim.schedule lua callback: ...hare/nvim/lazy/nvim-colorizer.lua/lua/colorizer/sass.lua:210: attempt to call field 'rehighlight' (a nil value)
stack traceback:
        ...hare/nvim/lazy/nvim-colorizer.lua/lua/colorizer/sass.lua:210: in function 'callback'
        ...are/nvim/lazy/nvim-colorizer.lua/lua/colorizer/utils.lua:141: in function 'on_change'
        ...are/nvim/lazy/nvim-colorizer.lua/lua/colorizer/utils.lua:155: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```