### PR TITLE
Fix/132 multiple virtualtext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SCRIPTS_DIR=scripts
 TRIE_TEST_SCRIPT=$(SCRIPTS_DIR)/trie-test.sh
 TRIE_BENCHMARK_SCRIPT=$(SCRIPTS_DIR)/trie-benchmark.sh
 MINIMAL_SCRIPT=$(SCRIPTS_DIR)/minimal-colorizer.sh
+MINIMAL_COLORIZER=colorizer_minimal
+MINIMAL_TRIE=colorizer_trie
 
 help:
 	@echo "Available targets:"
@@ -27,9 +29,9 @@ minimal:
 	@bash $(MINIMAL_SCRIPT)
 
 clean:
-	@echo "Removing test/colorizer_repro"
-	@rm -rf test/colorizer_repro
-	@echo "Removing test/trie/colorizer_trie"
-	@rm -rf test/trie/colorizer_trie
+	@echo "Removing test/"$(MINIMAL_COLORIZER)
+	@rm -rf test/$(MINIMAL_COLORIZER)
+	@echo "Removing test/trie/"$(MINIMAL_TRIE)
+	@rm -rf test/trie/$(MINIMAL_TRIE)
 
 .PHONY: help trie trie-test trie-benchmark minimal clean

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -405,6 +405,9 @@ function M.detach_from_buffer(bufnr)
   if bufnr < 0 then
     return -1
   end
+  for _, ns_id in pairs(const.namespace) do
+    vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+  end
   vim.api.nvim_buf_clear_namespace(bufnr, const.namespace.default, 0, -1)
   if colorizer_state.buffer_local[bufnr] then
     for _, namespace in pairs(colorizer_state.buffer_local[bufnr].__detach.ns_id) do

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -59,7 +59,6 @@ local function create_highlight(rgb_hex, mode)
   if mode == "foreground" then
     vim.api.nvim_set_hl(0, highlight_name, { fg = "#" .. rgb_hex })
   else
-    --  TODO: 2025-01-11 - Should this check for background or virtualtext
     local rr, gg, bb = rgb_hex:sub(1, 2), rgb_hex:sub(3, 4), rgb_hex:sub(5, 6)
     local r, g, b = tonumber(rr, 16), tonumber(gg, 16), tonumber(bb, 16)
     local fg_color = color.is_bright(r, g, b) and "Black" or "White"
@@ -296,7 +295,7 @@ function M.parse_lines(bufnr, lines, line_start, ud_opts)
     while i < #line do
       local length, rgb_hex = loop_parse_fn(line, i, bufnr)
       if length and not rgb_hex then
-        vim.api.nvim_err_writeln(
+        utils.log_message(
           string.format(
             "Colorizer: Error parsing line %d, index %d. Please report this issue.",
             line_nr,

--- a/lua/colorizer/constants.lua
+++ b/lua/colorizer/constants.lua
@@ -12,7 +12,6 @@ M.plugin = {
 -- - tailwind - Namespace used for creating extmarks to prevent tailwind name parsing from overwriting tailwind lsp highlights
 M.namespace = {
   default = vim.api.nvim_create_namespace(M.plugin.name),
-  tailwind_names = vim.api.nvim_create_namespace(M.plugin.name .. "_tailwind_names"),
   tailwind_lsp = vim.api.nvim_create_namespace(M.plugin.name .. "_tailwind_lsp"),
 }
 

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -27,8 +27,6 @@ parsers.prefix = {
   ["_hsla"] = parsers.hsl_function,
 }
 
---  TODO: 2024-12-31 - Return multiple parse_fn for tailwind parser?
-
 ---Form a trie stuct with the given prefixes
 ---@param matchers table: List of prefixes, {"rgb", "hsl"}
 ---@param matchers_trie table: Table containing information regarding non-trie based parsers

--- a/lua/colorizer/parser/names.lua
+++ b/lua/colorizer/parser/names.lua
@@ -77,9 +77,7 @@ local function handle_names_custom(names_custom)
     if status and type(result) == "table" then
       names = result
     else
-      vim.api.nvim_err_writeln(
-        "Error in names_custom function: " .. (result or "Invalid return value")
-      )
+      utils.log_message("Error in names_custom function: " .. (result or "Invalid return value"))
       return
     end
   end
@@ -92,11 +90,11 @@ local function handle_names_custom(names_custom)
       if normalized_hex:match("^%x%x%x%x%x%x$") then
         add_color(name, normalized_hex)
       else
-        vim.api.nvim_err_writeln("Invalid hex code for '" .. name .. "': " .. normalized_hex)
+        utils.log_message(string.format("Invalid hex code for '%s': %s", name, normalized_hex))
       end
     else
-      vim.api.nvim_err_writeln(
-        "Invalid value for '" .. name .. "': Expected string, got " .. type(hex)
+      utils.log_message(
+        string.format("Invalid value for '%s': Expected string, got %s", name, type(hex))
       )
     end
   end

--- a/lua/colorizer/tailwind.lua
+++ b/lua/colorizer/tailwind.lua
@@ -37,7 +37,7 @@ local function highlight(bufnr, ud_opts, add_highlight)
     lsp_cache[bufnr].document_params,
     function(err, results, _, _)
       if err ~= nil then
-        vim.api.nvim_err_writeln("tailwind.highlight: Error: " .. err)
+        utils.log_message("tailwind.highlight: Error: " .. err)
       end
       if err == nil and results ~= nil then
         local data, line_start, line_end = {}, nil, nil

--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -224,4 +224,12 @@ function M.visible_line_range(bufnr)
   return range[1] - 1, range[2]
 end
 
+function M.log_message(message)
+  if vim.version().minor >= 11 then
+    vim.api.nvim_echo({ { message, "ErrorMsg" } }, true, {})
+  else
+    vim.api.nvim_err_writeln(message)
+  end
+end
+
 return M

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,2 @@
-colorizer_repro/
+colorizer_minimal/
 colorizer_trie/

--- a/test/minimal-colorizer.lua
+++ b/test/minimal-colorizer.lua
@@ -1,8 +1,8 @@
 -- Run this file as `nvim --clean -u minimal-colorizer.lua`
 
 local settings = {
-  use_remote = false, -- Use colorizer master or local git directory
-  base_dir = "colorizer_repro", -- Directory to clone lazy.nvim
+  use_remote = true, -- Use colorizer master or local git directory
+  base_dir = "colorizer_minimal", -- Directory to clone lazy.nvim
   local_plugin_dir = os.getenv("HOME") .. "/git/nvim-colorizer.lua", -- Local git directory for colorizer.  Used if use_remote is false
   expect = "expect.lua",
   plugins = { -- add any additional plugins


### PR DESCRIPTION
- fix: clear all name spaces when detaching from buffer.  `tailwind_lsp` namespace is used to decouple lsp results from trie parsing.  Fixes issue where colorizer would could not be disabled on buffer if `tailwind = true` due to trie parsed highlights being assigned the removed `tailwind_names` namespace
- fix: when applying tailwind LSP highlights, if `tailwind = "both"` clear default highlights then reapply to areas not already highlighted by LSP namespace

closes #132 