### PR TITLE
feat: add type annotations for improved hinting and clarity

### DIFF
--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -143,7 +143,7 @@ local function validate_options(ud_opts)
     ud_opts.virtualtext_mode = plugin_user_default_options.virtualtext_mode
   end
   -- Extract table if names_custom is a function
-  if ud_opts.names and type(ud_opts.names_custom == "function") then
+  if ud_opts.names_custom and type(ud_opts.names_custom == "function") then
     local names
     local status, result = pcall(ud_opts.names_custom)
     if status and type(result) == "table" then


### PR DESCRIPTION
Following #134, I made a change that checks if `opts.user_default_config.names_custom` is available before going ahead to process it.

I also noticed that there is no type hinting, so I introduced type annotations to the plugin. This enhances code clarity and provides a better developer experience with proper type hinting.


