### PR TITLE
ref: when using colorizer.reload_on_save, but existing buffer options

### DIFF
--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -415,8 +415,6 @@ Provides configuration options and utilities for setting up colorizer.
 LUA API                                               *colorizer.config-lua-api*
 
 Functions: ~
-    |reset_cache| - Reset the cache for buffer options.
-
     |set_bo_value| - Set options for a specific buffer or file type.
 
     |apply_alias_options| - Parse and apply alias options to the user options.
@@ -434,14 +432,6 @@ Tables: ~
     |options| - Options for colorizer that were passed in to setup function
 
     |ud_opts| - Configuration options for the `setup` function.
-
-
-reset_cache()                                     *colorizer.config.reset_cache*
-    Reset the cache for buffer options.
-
-     Called from colorizer.setup
-
-
 
 
 set_bo_value({bo_type}, {val}, {ud_opts})        *colorizer.config.set_bo_value*

--- a/doc/modules/colorizer.config.html
+++ b/doc/modules/colorizer.config.html
@@ -70,10 +70,6 @@
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
-	<td class="name" nowrap><a href="#reset_cache">reset_cache ()</a></td>
-	<td class="summary">Reset the cache for buffer options.</td>
-	</tr>
-	<tr>
 	<td class="name" nowrap><a href="#set_bo_value">set_bo_value (bo_type, val, ud_opts)</a></td>
 	<td class="summary">Set options for a specific buffer or file type.</td>
 	</tr>
@@ -117,21 +113,6 @@
     <h2 class="section-header "><a name="Functions"></a>Functions</h2>
 
     <dl class="function">
-    <dt>
-    <a name = "reset_cache"></a>
-    <strong>reset_cache ()</strong>
-    </dt>
-    <dd>
-    Reset the cache for buffer options.
- Called from colorizer.setup
-
-
-
-
-
-
-
-</dd>
     <dt>
     <a name = "set_bo_value"></a>
     <strong>set_bo_value (bo_type, val, ud_opts)</strong>

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -254,10 +254,8 @@ function M.reload_on_save(pattern)
 
           vim.schedule(function()
             -- mimic bo_type_setup() function within colorizer.setup
-            local filetype = vim.bo.filetype
-            local buftype = vim.bo.buftype
             local bo_type = "filetype"
-            local ud_opts = config.get_bo_options(bo_type, buftype, filetype)
+            local ud_opts = config.get_bo_options(bo_type, vim.bo.buftype, vim.bo.filetype)
             M.attach_to_buffer(evt.buf, ud_opts, bo_type)
             vim.notify(
               "Colorizer reloaded with updated options from " .. evt.match,

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -253,7 +253,12 @@ function M.reload_on_save(pattern)
           colorizer_state.buffer_reload = buffer_reload
 
           vim.schedule(function()
-            M.attach_to_buffer()
+            -- mimic bo_type_setup() function within colorizer.setup
+            local filetype = vim.bo.filetype
+            local buftype = vim.bo.buftype
+            local bo_type = "filetype"
+            local ud_opts = config.get_bo_options(bo_type, buftype, filetype)
+            M.attach_to_buffer(evt.buf, ud_opts, bo_type)
             vim.notify(
               "Colorizer reloaded with updated options from " .. evt.match,
               vim.log.levels.INFO
@@ -461,12 +466,11 @@ function M.setup(opts)
   require("colorizer.matcher").reset_cache()
   require("colorizer.parser.names").reset_cache()
   require("colorizer.buffer").reset_cache()
-  require("colorizer.config").reset_cache()
 
   local s = config.get_setup_options(opts)
 
   -- Setup the buffer with the correct options
-  local function setup(bo_type)
+  local function bo_type_setup(bo_type)
     local filetype = vim.bo.filetype
     local buftype = vim.bo.buftype
     local bufnr = utils.bufme()
@@ -532,10 +536,10 @@ function M.setup(opts)
       callback = function()
         if s.lazy_load then
           vim.schedule(function()
-            setup(bo_type)
+            bo_type_setup(bo_type)
           end)
         else
-          setup(bo_type)
+          bo_type_setup(bo_type)
         end
       end,
     })

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -98,11 +98,16 @@ end
 local options_cache
 --- Reset the cache for buffer options.
 -- Called from colorizer.setup
-function M.reset_cache()
+local function init_cache()
   options_cache = { buftype = {}, filetype = {} }
 end
+
+local function init_config()
+  init_options()
+  init_cache()
+end
 do
-  M.reset_cache()
+  init_config()
 end
 
 --- Validate user options and set defaults.
@@ -251,7 +256,7 @@ end
 ---@param opts table|nil: Configuration options for colorizer.
 ---@return table: Final settings after merging user and default options.
 function M.get_setup_options(opts)
-  init_options()
+  init_config()
   opts = opts or {}
   opts.user_default_options = opts.user_default_options or plugin_user_default_options
   opts.user_default_options = M.apply_alias_options(opts.user_default_options)

--- a/test/expect.lua
+++ b/test/expect.lua
@@ -82,10 +82,12 @@ DeepSkyBlue DeepSkyBlue2
 DEEPSKYBLUE DEEPSKYBLUE3
 
 Extra names:
+From function defined in `user_default_options`
   oniViolet oniViolet2 crystalBlue springViolet1 springViolet2 springBlue
   lightBlue waveAqua2
 
 Custom names with non-alphanumeric characters:
+From table in filetype definiton (lua)
   one_two three=four five@six seven!eight nine!!ten
    NOTE: TODO:  WARN:   FIX:  .
    NOTE:


### PR DESCRIPTION
- test: when using colorizer.reload_on_save, use existing buffer options.  Allows for `names_custom` to be defined for both `user_default_options` and filetype:

![image](https://github.com/user-attachments/assets/d2498f4b-9beb-4846-90e9-072e52455502)
