### PR TITLE
fix: removes mystery argument to vim.json.encode

### DIFF
--- a/lua/colorizer/utils.lua
+++ b/lua/colorizer/utils.lua
@@ -235,7 +235,7 @@ end
 --- Returns sha256 hash of lua table
 ---@param tbl table: Table to be hashed
 function M.hash_table(tbl)
-  local json_string = vim.json.encode(tbl, { sort_keys = true })
+  local json_string = vim.json.encode(tbl)
   return vim.fn.sha256(json_string)
 end
 


### PR DESCRIPTION
Removes unknown argument to `vim.json.encode`.

Closes #139