### PR TITLE
fix(sass): invalid buffer options

### DIFF
--- a/lua/colorizer/sass.lua
+++ b/lua/colorizer/sass.lua
@@ -209,7 +209,7 @@ local function sass_parse_lines(bufnr, line_start, content, name)
 
                     require("colorizer").rehighlight(
                       bufnr,
-                      state[bufnr].options,
+                      state[bufnr].ud_opts,
                       state[bufnr].local_options,
                       { use_local_lines = true }
                     )


### PR DESCRIPTION
There's no `options` property in `state[bufnr]` as seen in `update_variables` function: https://github.com/catgoose/nvim-colorizer.lua/blob/2933cb5b547b8a2dba20e8087d488462ad5bc6bc/lua/colorizer/sass.lua#L270

closes: #142 