### PR TITLE
fix(rgb): Invalid number comparison

### DIFF
--- a/lua/colorizer/parser/rgb.lua
+++ b/lua/colorizer/parser/rgb.lua
@@ -73,6 +73,9 @@ function M.parser(line, i, opts)
     a = 1
   else
     a = tonumber(a)
+    if not a then
+      return
+    end
     -- Convert percentage alpha to decimal if applicable
     if unit_a == "%" then
       a = a / 100


### PR DESCRIPTION
Error  12:36:16 PM IST msg_show.lua_error Error detected while processing TextChangedI Autocommands for "<buffer=1>":
12:36:16 PM IST msg_show Error executing lua callback: ...vim/lazy/nvim-colorizer.lua/lua/colorizer/parser/rgb.lua:80: attempt to compare number with nil
stack traceback:
	...vim/lazy/nvim-colorizer.lua/lua/colorizer/parser/rgb.lua:80: in function 'loop_parse_fn'
	...re/nvim/lazy/nvim-colorizer.lua/lua/colorizer/buffer.lua:295: in function 'parse_lines'
	...re/nvim/lazy/nvim-colorizer.lua/lua/colorizer/buffer.lua:260: in function 'highlight_buffer'
	...cal/share/nvim/lazy/nvim-colorizer.lua/lua/colorizer.lua:165: in function 'rehighlight'
	...cal/share/nvim/lazy/nvim-colorizer.lua/lua/colorizer.lua:357: in function <...cal/share/nvim/lazy/nvim-colorizer.lua/lua/colorizer.lua:346>
