### PR TITLE
fix!: fixes hooks.disable_line_highlight function signature to match …

### DIFF
--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -40,7 +40,7 @@ local function compile(matchers, matchers_trie, hooks)
     if
       hooks
       and hooks.disable_line_highlight
-      and hooks.disable_line_highlight(line, line_nr, bufnr)
+      and hooks.disable_line_highlight(line, bufnr, line_nr)
     then
       return
     end


### PR DESCRIPTION
I guess nobody uses this hook since it's been broken forever :D