### PR TITLE
fix: should prioritize colorizer highlight over treesitter

### DIFF
--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -69,7 +69,7 @@ local function create_highlight(rgb_hex, mode)
   return highlight_name
 end
 
-local PRIORITY_DEFAULT = 100
+local PRIORITY_DEFAULT = 150
 local PRIORITY_LSP = 200
 
 local function slice_line(bufnr, line, start_col, end_col)

--- a/tests/test_buffer_highlight.lua
+++ b/tests/test_buffer_highlight.lua
@@ -201,14 +201,14 @@ end
 
 T["priority"] = new_set()
 
-T["priority"]["default priority is 100"] = function()
+T["priority"]["default priority is 150"] = function()
   local buf = make_buf({ "#FF0000" })
   local ns = vim.api.nvim_create_namespace("test_priority_default")
   local opts = all_opts({ mode = "background" })
   local data = buffer.parse_lines(buf, { "#FF0000" }, 0, opts)
   buffer.add_highlight(buf, ns, 0, 1, data, opts)
   local marks = vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })
-  eq(100, marks[1][4].priority)
+  eq(150, marks[1][4].priority)
   vim.api.nvim_buf_delete(buf, { force = true })
 end
 


### PR DESCRIPTION
Increase the default priority of colorizer highlightings from 100 to 150 to avoid them from being overridden by treesitter highlights.

Before:

<img width="1058" height="1239" alt="image" src="https://github.com/user-attachments/assets/6f21197e-ed5d-4388-b4c2-782462a620e8" />

After:

<img width="1058" height="1239" alt="image" src="https://github.com/user-attachments/assets/79810943-07d8-4d23-8bad-b5cc81dcfb98" />
